### PR TITLE
Fixes pokemon images by pulling them from a different source.

### DIFF
--- a/src/main/kotlin/com/martmists/PokemonOverlay/Pokemon.kt
+++ b/src/main/kotlin/com/martmists/PokemonOverlay/Pokemon.kt
@@ -35,7 +35,7 @@ class Pokemon(id: Any) {
 
             name = json.getString("name")
             nickname = name
-            icon = json.getString("url")
+            icon = "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/" + json.getString("dexno") + ".png"
         } else {
             icon = "http://via.placeholder.com/0x0/f4f4f4/f4f4f4"
             ball = "http://via.placeholder.com/0x0/f4f4f4/f4f4f4"

--- a/src/main/kotlin/com/martmists/PokemonOverlay/Pokemon.kt
+++ b/src/main/kotlin/com/martmists/PokemonOverlay/Pokemon.kt
@@ -35,7 +35,7 @@ class Pokemon(id: Any) {
 
             name = json.getString("name")
             nickname = name
-            icon = "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/" + json.getString("dexno") + ".png"
+            icon = "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/" + id + ".png"
         } else {
             icon = "http://via.placeholder.com/0x0/f4f4f4/f4f4f4"
             ball = "http://via.placeholder.com/0x0/f4f4f4/f4f4f4"

--- a/src/main/kotlin/com/martmists/PokemonOverlay/PokemonStyle.kt
+++ b/src/main/kotlin/com/martmists/PokemonOverlay/PokemonStyle.kt
@@ -72,8 +72,8 @@ class PokemonStyle: Stylesheet() {
         }
 
         PokemonIcon {
-            scaleX = 1.75
-            scaleY = 1.75
+            scaleX = 0.75
+            scaleY = 0.75
         }
 
         ItemName {

--- a/src/main/kotlin/com/martmists/PokemonOverlay/PokemonView.kt
+++ b/src/main/kotlin/com/martmists/PokemonOverlay/PokemonView.kt
@@ -39,8 +39,8 @@ class PokemonView : View() {
                     pane {
                         addClass(PokemonStyle.Inner)
                         imageview(getImage(empty.icon)).apply {
-                            layoutX = 10.0
-                            layoutY = 10.0
+                            layoutX = -17.0
+                            layoutY = -17.0
                             addClass(PokemonStyle.PokemonIcon)
                         }
                         label {
@@ -117,8 +117,8 @@ class PokemonView : View() {
                     pane {
                         addClass(PokemonStyle.Inner)
                         imageview(getImage(empty.icon)).apply {
-                            layoutX = 10.0
-                            layoutY = 10.0
+                            layoutX = -17.0
+                            layoutY = -17.0
                             addClass(PokemonStyle.PokemonIcon)
                         }
                         label {
@@ -198,8 +198,8 @@ class PokemonView : View() {
                     pane {
                         addClass(PokemonStyle.Inner)
                         imageview(getImage(empty.icon)).apply {
-                            layoutX = 10.0
-                            layoutY = 10.0
+                            layoutX = -17.0
+                            layoutY = -17.0
                             addClass(PokemonStyle.PokemonIcon)
                         }
                         label {
@@ -276,8 +276,8 @@ class PokemonView : View() {
                     pane {
                         addClass(PokemonStyle.Inner)
                         imageview(getImage(empty.icon)).apply {
-                            layoutX = 10.0
-                            layoutY = 10.0
+                            layoutX = -17.0
+                            layoutY = -17.0
                             addClass(PokemonStyle.PokemonIcon)
                         }
                         label {
@@ -357,8 +357,8 @@ class PokemonView : View() {
                     pane {
                         addClass(PokemonStyle.Inner)
                         imageview(getImage(empty.icon)).apply {
-                            layoutX = 10.0
-                            layoutY = 10.0
+                            layoutX = -17.0
+                            layoutY = -17.0
                             addClass(PokemonStyle.PokemonIcon)
                         }
                         label {
@@ -435,8 +435,8 @@ class PokemonView : View() {
                     pane {
                         addClass(PokemonStyle.Inner)
                         imageview(getImage(empty.icon)).apply {
-                            layoutX = 10.0
-                            layoutY = 10.0
+                            layoutX = -17.0
+                            layoutY = -17.0
                             addClass(PokemonStyle.PokemonIcon)
                         }
                         label {


### PR DESCRIPTION
Opening this pull request to show the code changes I made in attempts to fix #6. I think previously it was using the party icons rather than the in-battle sprites but I found what appears to be a reliable source to get the battle sprites from so I opted for those instead. Of course I needed to change the layout a bit as well since they are bigger. Now they call come from the same url (the only difference being the pokedex number at the end) so I hardcoded that URL into the code substituting the dexno value from out.json. Of course this means the url properties in out.json are obsolete, but they are still there for now. See #6 for a picture of what that looks like.